### PR TITLE
Add support for Kafka datasources

### DIFF
--- a/syntaxes/tinybird.tmLanguage.json
+++ b/syntaxes/tinybird.tmLanguage.json
@@ -9,6 +9,8 @@
 		{ "include": "#sql_section" },
 		{ "include": "#oneliner_section" },
 		{ "include": "#oneliner_meta" },
+		{ "include": "#oneliner_meta_engine" },
+		{ "include": "#oneliner_meta_kafka" },
 		{ "include": "#comment" },
 		{ "include": "source.sql" }
 	],
@@ -53,7 +55,21 @@
 		},
 
 		"oneliner_meta": {
-			"begin": "ENGINE[^_]|ENGINE_PARTITION_KEY|ENGINE_SORTING_KEY|ENGINE_SETTINGS|TYPE|DATASOURCE|TOKEN\\b",
+			"begin": "TYPE|DATASOURCE|TOKEN\\b",
+			"end": "$",
+			"captures": { "0": { "name":"keyword" } },
+			"patterns": [{ "include": "source.sql" }]
+		},
+
+		"oneliner_meta_engine": {
+			"begin": "ENGINE[^_]|ENGINE_(PARTITION_KEY|SORTING_KEY|SAMPLING_KEY|SETTINGS|VER|SIGN|TTL)\\b",
+			"end": "$",
+			"captures": { "0": { "name":"keyword" } },
+			"patterns": [{ "include": "source.sql" }]
+		},
+
+		"oneliner_meta_kafka": {
+			"begin": "KAFKA_(CONNECTION_NAME|TOPIC|GROUP_ID|AUTO_OFFSET_RESET|STORE_RAW_VALUE|TARGET_PARTITIONS)\\b",
 			"end": "$",
 			"captures": { "0": { "name":"keyword" } },
 			"patterns": [{ "include": "source.sql" }]


### PR DESCRIPTION
## Description

Add highlighting for `KAFKA_` options on datasource files.

Current behaviour:

![image](https://user-images.githubusercontent.com/3041948/176751263-455197b2-4dec-4b84-8ae3-cf2838cc98dd.png)

## Technical details

I've splitted [`oneliner_meta`](https://github.com/tinybirdco/vscode-tinybird-support/blob/main/syntaxes/tinybird.tmLanguage.json#L55) element into `oneliner_meta`, `oneliner_meta_engine` and `oneliner_meta_kafka` for better maintainability.

It's just a suggestion, feel free to modify it to you liking 😀

