### PR TITLE
Fix error on start when `.tinyb` token has changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-tinybird-support",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-tinybird-support",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tinybird-support",
   "displayName": "Tinybird support for Visual Studio Code",
   "description": "This extension provides syntax highlighting and commands for Tinybird data projects.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "engines": {
     "vscode": "^1.74.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { getWorkspace } from './api/workspaces'
 
 export function activate(context: vscode.ExtensionContext) {
   const tinybirdContext = getContext(context)
+  tinybirdContext.clearToken()
   const dataSourceView = new DataSourceView(tinybirdContext)
   const pipeView = new PipeView(tinybirdContext)
   const tokenView = new TokenView(tinybirdContext)

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -60,6 +60,10 @@ export async function fetcher<
       throw new Error('Tinybird: Invalid token')
     }
 
+    if (response.status == 403) {
+      throw new Error('Tinybird: Access denied. Your token tried to enter a restricted nest!')
+    }
+
     if (response.status === 204 /* no content */) {
       return { success: true, data: undefined as any }
     }


### PR DESCRIPTION
Fixes https://github.com/tinybirdco/vscode-tinybird-support/issues/27

![image](https://github.com/tinybirdco/vscode-tinybird-support/assets/38496681/cf7f32f9-5497-435f-a250-00b3a4b70d89)

The log was:

```
notificationsAlerts.ts:40 Error: 
    at Object.fetchPipes (/home/rbarbadillo/.vscode/extensions/tinybirdco.vscode-tinybird-support-1.0.2/src/context.ts:70:15)
    at process.getPipes (node:internal/process/task_queues:95:5)
    at d.getChildren (/home/rbarbadillo/.vscode/extensions/tinybirdco.vscode-tinybird-support-1.0.2/src/views/pipes.ts:55:34)
    at c.Y (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:125:66905)
    at c.getChildren (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:125:63275)
c @ notificationsAlerts.ts:40
notificationsAlerts.ts:40 Error: 
    at d.getChildren (/home/rbarbadillo/.vscode/extensions/tinybirdco.vscode-tinybird-support-1.0.2/src/views/tokens.ts:45:15)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at c.Y (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:125:66905)
    at c.getChildren (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:125:63275)
c @ notificationsAlerts.ts:40
notificationsAlerts.ts:40 Error: 
    at Object.fetchDataSources (/home/rbarbadillo/.vscode/extensions/tinybirdco.vscode-tinybird-support-1.0.2/src/context.ts:81:15)
    at process.getDataSources (node:internal/process/task_queues:95:5)
    at d.getChildren (/home/rbarbadillo/.vscode/extensions/tinybirdco.vscode-tinybird-support-1.0.2/src/views/datasources.ts:57:22)
    at c.Y (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:125:66905)
    at c.getChildren (/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:125:63275)
c @ notificationsAlerts.ts:40
```

What was going on:

- The API was returning a 403 => Added a better log for that error.
- The first-loaded token from the .tinyb file was incorrect. I changed it on the file but it was not refreshing. I have added a line to clear the Token from the context info on start, to make sure it is loaded on start. (This can also be a security issue, someone might change the `.tinyb` file willingly to restrict access)